### PR TITLE
feat: replace [pin] on initial kick and fix pinCheck boot warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,13 @@ jobs:
         with:
           path: |
             .gradle/loom-cache
-          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-loom-
 
       - name: Execute Gradle build
         env:
           STORAGE_TYPE: ${{ matrix.storageType }}
-        run: ./gradlew build --build-cache --info
+        run: ./gradlew build --build-cache --refresh-dependencies --info
 
       - name: Build all Fabric versions
         run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,15 @@ jobs:
         working-directory: BanManager
         run: ./gradlew publishToMavenLocal --build-cache
 
+      - name: Clear stale BanManager dependency caches
+        run: |
+          find ~/.gradle/caches -path "*/me.confuser.banmanager*" -exec rm -rf {} + 2>/dev/null || true
+          find .gradle/loom-cache -path "*/BanManager*" -exec rm -rf {} + 2>/dev/null || true
+
       - name: Execute Gradle build
         env:
           STORAGE_TYPE: ${{ matrix.storageType }}
-        run: ./gradlew build --build-cache --info
+        run: ./gradlew build --build-cache --refresh-dependencies --info
 
       - name: Build all Fabric versions
-        run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache
+        run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache --refresh-dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,4 +71,4 @@ jobs:
         run: ./gradlew build --build-cache --refresh-dependencies --info
 
       - name: Build all Fabric versions
-        run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache --refresh-dependencies
+        run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/checkout@v4
+        with:
+          repository: BanManagement/BanManager
+          path: BanManager
+          ref: master
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -47,13 +53,17 @@ jobs:
         with:
           path: |
             .gradle/loom-cache
-          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-loom-
+
+      - name: Publish BanManager to Maven Local
+        working-directory: BanManager
+        run: ./gradlew publishToMavenLocal --build-cache
 
       - name: Execute Gradle build
         env:
           STORAGE_TYPE: ${{ matrix.storageType }}
-        run: ./gradlew build --build-cache --refresh-dependencies --info
+        run: ./gradlew build --build-cache --info
 
       - name: Build all Fabric versions
         run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,8 +132,12 @@ jobs:
         with:
           path: |
             .gradle/loom-cache
-          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-loom-
+
+      - name: Publish BanManager to Maven Local
+        working-directory: BanManager
+        run: ./gradlew publishToMavenLocal --build-cache
 
       # Docker Buildx for better caching
       - name: Set up Docker Buildx

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -139,6 +139,11 @@ jobs:
         working-directory: BanManager
         run: ./gradlew publishToMavenLocal --build-cache
 
+      - name: Clear stale BanManager dependency caches
+        run: |
+          find ~/.gradle/caches -path "*/me.confuser.banmanager*" -exec rm -rf {} + 2>/dev/null || true
+          find .gradle/loom-cache -path "*/BanManager*" -exec rm -rf {} + 2>/dev/null || true
+
       # Docker Buildx for better caching
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -175,7 +180,7 @@ jobs:
         run: ./gradlew ${{ matrix.build_task }} --build-cache
 
       - name: Run E2E tests
-        run: ./gradlew :BanManagerWebEnhancerE2E:${{ matrix.task }} --build-cache -PbanManagerPath=BanManager
+        run: ./gradlew :BanManagerWebEnhancerE2E:${{ matrix.task }} --build-cache --refresh-dependencies -PbanManagerPath=BanManager
         timeout-minutes: 15
         env:
           MC_VERSION: ${{ matrix.mc_version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           path: |
             .gradle/loom-cache
-          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-loom-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-loom-
 
       # Docker Buildx for better caching

--- a/bukkit/src/main/java/me/confuser/banmanager/webenhancer/bukkit/listeners/ReportListener.java
+++ b/bukkit/src/main/java/me/confuser/banmanager/webenhancer/bukkit/listeners/ReportListener.java
@@ -1,10 +1,12 @@
 package me.confuser.banmanager.webenhancer.bukkit.listeners;
 
 import me.confuser.banmanager.common.ormlite.stmt.DeleteBuilder;
+import me.confuser.banmanager.bukkit.api.events.PlayerBannedEvent;
 import me.confuser.banmanager.bukkit.api.events.PlayerReportDeletedEvent;
 import me.confuser.banmanager.bukkit.api.events.PlayerReportedEvent;
 import me.confuser.banmanager.bukkit.api.events.PlayerDeniedEvent;
 import me.confuser.banmanager.bukkit.api.events.PluginReloadedEvent;
+import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.common.data.PlayerReportData;
 import me.confuser.banmanager.webenhancer.bukkit.BukkitPlugin;
 import me.confuser.banmanager.webenhancer.common.data.LogData;
@@ -74,6 +76,17 @@ public class ReportListener implements Listener {
   @EventHandler
   public void onDeny(PlayerDeniedEvent event) {
     listener.handlePin(event.getPlayer(), event.getMessage());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onBanned(PlayerBannedEvent event) {
+    try {
+      Message kickMessage = event.getKickMessage();
+      if (kickMessage != null) {
+        listener.handlePin(event.getBan().getPlayer(), kickMessage);
+      }
+    } catch (NoSuchMethodError ignored) {
+    }
   }
 
   @EventHandler

--- a/bungee/src/main/java/me/confuser/banmanager/webenhancer/bungee/listeners/BanListener.java
+++ b/bungee/src/main/java/me/confuser/banmanager/webenhancer/bungee/listeners/BanListener.java
@@ -1,7 +1,9 @@
 package me.confuser.banmanager.webenhancer.bungee.listeners;
 
+import me.confuser.banmanager.bungee.api.events.PlayerBannedEvent;
 import me.confuser.banmanager.bungee.api.events.PlayerDeniedEvent;
 import me.confuser.banmanager.bungee.api.events.PluginReloadedEvent;
+import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.webenhancer.bungee.BungeePlugin;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
@@ -19,6 +21,17 @@ public class BanListener implements Listener {
   @EventHandler
   public void onDeny(PlayerDeniedEvent event) {
     listener.handlePin(event.getPlayer(), event.getMessage());
+  }
+
+  @EventHandler
+  public void onBanned(PlayerBannedEvent event) {
+    try {
+      Message kickMessage = event.getKickMessage();
+      if (kickMessage != null) {
+        listener.handlePin(event.getBan().getPlayer(), kickMessage);
+      }
+    } catch (NoSuchMethodError ignored) {
+    }
   }
 
   @EventHandler

--- a/common/src/main/java/me/confuser/banmanager/webenhancer/common/runnables/ExpiresSync.java
+++ b/common/src/main/java/me/confuser/banmanager/webenhancer/common/runnables/ExpiresSync.java
@@ -1,8 +1,6 @@
 package me.confuser.banmanager.webenhancer.common.runnables;
 
 import me.confuser.banmanager.common.ormlite.stmt.DeleteBuilder;
-import me.confuser.banmanager.common.BanManagerPlugin;
-import me.confuser.banmanager.common.runnables.BmRunnable;
 import me.confuser.banmanager.common.util.DateUtils;
 import me.confuser.banmanager.webenhancer.common.WebEnhancerPlugin;
 import me.confuser.banmanager.webenhancer.common.data.PlayerPinData;
@@ -10,12 +8,10 @@ import me.confuser.banmanager.webenhancer.common.storage.PlayerPinStorage;
 
 import java.sql.SQLException;
 
-public class ExpiresSync extends BmRunnable {
+public class ExpiresSync implements Runnable {
   private PlayerPinStorage pinStorage;
 
   public ExpiresSync(WebEnhancerPlugin plugin) {
-    super(BanManagerPlugin.getInstance(), "pinCheck");
-
     pinStorage = plugin.getPlayerPinStorage();
   }
 

--- a/e2e/platforms/bukkit/configs/banmanager/messages.yml
+++ b/e2e/platforms/bukkit/configs/banmanager/messages.yml
@@ -136,7 +136,7 @@ messages:
   ban:
     player:
       disallowed: '&6You have been banned from this server for &4[reason]&6. Your appeal pin is [pin]'
-      kick: '&6You have been banned permanently for &4[reason]'
+      kick: '&6You have been banned permanently for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been permanently banned by [actor] for &4[reason]'
     error:
@@ -149,7 +149,7 @@ messages:
   tempban:
     player:
       disallowed: '&6You have been temporarily banned from this server for &4[reason] \n&6It expires in [expires]. Your appeal pin is [pin]'
-      kick: '&6You have been temporarily banned for &4[reason]'
+      kick: '&6You have been temporarily banned for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been temporarily banned for [expires] by [actor] for &4[reason]'
 

--- a/e2e/platforms/bungee/configs/banmanager/messages.yml
+++ b/e2e/platforms/bungee/configs/banmanager/messages.yml
@@ -143,7 +143,7 @@ messages:
     player:
       disallowed: '&6You have been banned from this server for &4[reason]&6. Your
         appeal pin is [pin]'
-      kick: '&6You have been banned permanently for &4[reason]'
+      kick: '&6You have been banned permanently for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: yyyy-MM-dd HH:mm:ss
     notify: '&6[player] has been permanently banned by [actor] for &4[reason]'
     error:
@@ -155,7 +155,7 @@ messages:
     player:
       disallowed: '&6You have been temporarily banned from this server for &4[reason]
         \n&6It expires in [expires]. Your appeal pin is [pin]'
-      kick: '&6You have been temporarily banned for &4[reason]'
+      kick: '&6You have been temporarily banned for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: yyyy-MM-dd HH:mm:ss
     notify: '&6[player] has been temporarily banned for [expires] by [actor] for &4[reason]'
   tempbanall:

--- a/e2e/platforms/fabric/configs/banmanager/messages.yml
+++ b/e2e/platforms/fabric/configs/banmanager/messages.yml
@@ -142,7 +142,7 @@ messages:
   ban:
     player:
       disallowed: '&6You have been banned from this server for &4[reason]&6. Your appeal pin is [pin]'
-      kick: '&6You have been banned permanently for &4[reason]'
+      kick: '&6You have been banned permanently for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been permanently banned by [actor] for &4[reason]'
     error:
@@ -155,7 +155,7 @@ messages:
   tempban:
     player:
       disallowed: '&6You have been temporarily banned from this server for &4[reason] \n&6It expires in [expires]. Your appeal pin is [pin]'
-      kick: '&6You have been temporarily banned for &4[reason]'
+      kick: '&6You have been temporarily banned for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been temporarily banned for [expires] by [actor] for &4[reason]'
 

--- a/e2e/platforms/sponge/configs/banmanager/messages.yml
+++ b/e2e/platforms/sponge/configs/banmanager/messages.yml
@@ -136,7 +136,7 @@ messages:
   ban:
     player:
       disallowed: '&6You have been banned from this server for &4[reason]&6. Your appeal pin is [pin]'
-      kick: '&6You have been banned permanently for &4[reason]'
+      kick: '&6You have been banned permanently for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been permanently banned by [actor] for &4[reason]'
     error:
@@ -149,7 +149,7 @@ messages:
   tempban:
     player:
       disallowed: '&6You have been temporarily banned from this server for &4[reason] \n&6It expires in [expires]. Your appeal pin is [pin]'
-      kick: '&6You have been temporarily banned for &4[reason]'
+      kick: '&6You have been temporarily banned for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been temporarily banned for [expires] by [actor] for &4[reason]'
 

--- a/e2e/platforms/sponge7/configs/banmanager/messages.yml
+++ b/e2e/platforms/sponge7/configs/banmanager/messages.yml
@@ -136,7 +136,7 @@ messages:
   ban:
     player:
       disallowed: '&6You have been banned from this server for &4[reason]&6. Your appeal pin is [pin]'
-      kick: '&6You have been banned permanently for &4[reason]'
+      kick: '&6You have been banned permanently for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been permanently banned by [actor] for &4[reason]'
     error:
@@ -149,7 +149,7 @@ messages:
   tempban:
     player:
       disallowed: '&6You have been temporarily banned from this server for &4[reason] \n&6It expires in [expires]. Your appeal pin is [pin]'
-      kick: '&6You have been temporarily banned for &4[reason]'
+      kick: '&6You have been temporarily banned for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss'
     notify: '&6[player] has been temporarily banned for [expires] by [actor] for &4[reason]'
 

--- a/e2e/platforms/velocity/configs/banmanager/messages.yml
+++ b/e2e/platforms/velocity/configs/banmanager/messages.yml
@@ -143,7 +143,7 @@ messages:
     player:
       disallowed: '&6You have been banned from this server for &4[reason]&6. Your
         appeal pin is [pin]'
-      kick: '&6You have been banned permanently for &4[reason]'
+      kick: '&6You have been banned permanently for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: yyyy-MM-dd HH:mm:ss
     notify: '&6[player] has been permanently banned by [actor] for &4[reason]'
     error:
@@ -155,7 +155,7 @@ messages:
     player:
       disallowed: '&6You have been temporarily banned from this server for &4[reason]
         \n&6It expires in [expires]. Your appeal pin is [pin]'
-      kick: '&6You have been temporarily banned for &4[reason]'
+      kick: '&6You have been temporarily banned for &4[reason]&6. Your appeal pin is [pin]'
       dateTimeFormat: yyyy-MM-dd HH:mm:ss
     notify: '&6[player] has been temporarily banned for [expires] by [actor] for &4[reason]'
   tempbanall:

--- a/e2e/tests/src/denied-pin.test.ts
+++ b/e2e/tests/src/denied-pin.test.ts
@@ -34,11 +34,11 @@ describe('Denied Pin Placeholder', () => {
   }
 
   afterEach(async () => {
-    try {
-      await sendCommand(`bmunban ${BANNED_USERNAME}`)
-    } catch (e) {}
     await bannedBot?.disconnect()
     bannedBot = null
+    try { await sendCommand(`bmunban ${BANNED_USERNAME}`) } catch (e) {}
+    try { await sendCommand(`bmuntempban ${BANNED_USERNAME}`) } catch (e) {}
+    await sleep(2000)
   })
 
   test('[pin] placeholder in ban message is replaced with actual pin', async () => {
@@ -64,7 +64,7 @@ describe('Denied Pin Placeholder', () => {
   test('[pin] placeholder in tempban message is replaced with actual pin', async () => {
     const tempbanResponse = await sendCommand(`bmtempban ${BANNED_USERNAME} 1h Testing tempban pin placeholder`)
     console.log(`Tempban response: ${tempbanResponse}`)
-    await sleep(3000)
+    await sleep(5000)
 
     const errorMessage = await expectDeniedConnection()
     console.log(`Player was denied (tempban) as expected: ${errorMessage}`)
@@ -91,9 +91,8 @@ describe('Online Kick Pin Placeholder', () => {
   afterEach(async () => {
     await bot?.disconnect()
     bot = null
-    try {
-      await sendCommand(`bmunban ${KICK_USERNAME}`)
-    } catch (e) {}
+    try { await sendCommand(`bmunban ${KICK_USERNAME}`) } catch (e) {}
+    try { await sendCommand(`bmuntempban ${KICK_USERNAME}`) } catch (e) {}
     await sleep(2000)
   })
 

--- a/e2e/tests/src/denied-pin.test.ts
+++ b/e2e/tests/src/denied-pin.test.ts
@@ -5,19 +5,20 @@ afterAll(async () => {
 })
 
 describe('Denied Pin Placeholder', () => {
-  let bannedBot: TestBot | null = null
   const BANNED_USERNAME = 'DeniedPinPlayer'
-  const TEST_TIMEOUT_MS = 60000
+  const TEST_TIMEOUT_MS = 120000
 
   const expectDeniedConnection = async (): Promise<string> => {
     let lastError: Error | null = null
 
     // Ban/tempban enforcement can be async across worker threads; retry denied connect checks.
-    for (let attempt = 1; attempt <= 5; attempt++) {
+    // Use a short connect timeout (10s) so limbo connections (neither kicked nor spawned)
+    // don't burn the full 30s default, leaving room for more retries.
+    for (let attempt = 1; attempt <= 8; attempt++) {
+      const bot = new TestBot(BANNED_USERNAME)
       try {
-        bannedBot = await createBot(BANNED_USERNAME)
-        await bannedBot.disconnect()
-        bannedBot = null
+        await bot.connect(10000)
+        await bot.disconnect()
         lastError = new Error(`Attempt ${attempt}: player connected while expected to be denied`)
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error)
@@ -25,6 +26,7 @@ describe('Denied Pin Placeholder', () => {
           return errorMessage
         }
         lastError = error instanceof Error ? error : new Error(String(error))
+        try { await bot.disconnect() } catch (e) {}
       }
 
       await sleep(2000)
@@ -34,8 +36,6 @@ describe('Denied Pin Placeholder', () => {
   }
 
   afterEach(async () => {
-    await bannedBot?.disconnect()
-    bannedBot = null
     try { await sendCommand(`bmunban ${BANNED_USERNAME}`) } catch (e) {}
     try { await sendCommand(`bmuntempban ${BANNED_USERNAME}`) } catch (e) {}
     await sleep(2000)

--- a/e2e/tests/src/denied-pin.test.ts
+++ b/e2e/tests/src/denied-pin.test.ts
@@ -13,7 +13,7 @@ describe('Denied Pin Placeholder', () => {
     let lastError: Error | null = null
 
     // Ban/tempban enforcement can be async across worker threads; retry denied connect checks.
-    for (let attempt = 1; attempt <= 3; attempt++) {
+    for (let attempt = 1; attempt <= 5; attempt++) {
       try {
         bannedBot = await createBot(BANNED_USERNAME)
         await bannedBot.disconnect()
@@ -27,7 +27,7 @@ describe('Denied Pin Placeholder', () => {
         lastError = error instanceof Error ? error : new Error(String(error))
       }
 
-      await sleep(1000)
+      await sleep(2000)
     }
 
     throw lastError ?? new Error('Expected denied connection but did not receive a denial kick')
@@ -64,7 +64,7 @@ describe('Denied Pin Placeholder', () => {
   test('[pin] placeholder in tempban message is replaced with actual pin', async () => {
     const tempbanResponse = await sendCommand(`bmtempban ${BANNED_USERNAME} 1h Testing tempban pin placeholder`)
     console.log(`Tempban response: ${tempbanResponse}`)
-    await sleep(2000)
+    await sleep(3000)
 
     const errorMessage = await expectDeniedConnection()
     console.log(`Player was denied (tempban) as expected: ${errorMessage}`)
@@ -89,11 +89,12 @@ describe('Online Kick Pin Placeholder', () => {
   let bot: TestBot | null = null
 
   afterEach(async () => {
+    await bot?.disconnect()
+    bot = null
     try {
       await sendCommand(`bmunban ${KICK_USERNAME}`)
     } catch (e) {}
-    await bot?.disconnect()
-    bot = null
+    await sleep(2000)
   })
 
   test('[pin] placeholder in kick message is replaced when banning an online player', async () => {

--- a/e2e/tests/src/denied-pin.test.ts
+++ b/e2e/tests/src/denied-pin.test.ts
@@ -1,5 +1,9 @@
 import { TestBot, createBot, sendCommand, disconnectRcon, sleep } from './helpers'
 
+afterAll(async () => {
+  await disconnectRcon()
+})
+
 describe('Denied Pin Placeholder', () => {
   let bannedBot: TestBot | null = null
   const BANNED_USERNAME = 'DeniedPinPlayer'
@@ -35,10 +39,6 @@ describe('Denied Pin Placeholder', () => {
     } catch (e) {}
     await bannedBot?.disconnect()
     bannedBot = null
-  })
-
-  afterAll(async () => {
-    await disconnectRcon()
   })
 
   test('[pin] placeholder in ban message is replaced with actual pin', async () => {
@@ -78,6 +78,68 @@ describe('Denied Pin Placeholder', () => {
     if (pinMatch != null) {
       const pin = pinMatch[1]
       console.log(`Extracted pin from tempban message: ${pin}`)
+      expect(pin).toMatch(/^\d{6}$/)
+    }
+  }, TEST_TIMEOUT_MS)
+})
+
+describe('Online Kick Pin Placeholder', () => {
+  const KICK_USERNAME = 'OnlineKickPin'
+  const TEST_TIMEOUT_MS = 60000
+  let bot: TestBot | null = null
+
+  afterEach(async () => {
+    try {
+      await sendCommand(`bmunban ${KICK_USERNAME}`)
+    } catch (e) {}
+    await bot?.disconnect()
+    bot = null
+  })
+
+  test('[pin] placeholder in kick message is replaced when banning an online player', async () => {
+    bot = await createBot(KICK_USERNAME)
+    const kickPromise = bot.waitForKick()
+
+    await sleep(1000)
+    const banResponse = await sendCommand(`bmban ${KICK_USERNAME} Testing online kick pin`)
+    console.log(`Ban response: ${banResponse}`)
+
+    const kickReason = await kickPromise
+    console.log(`Online player kicked with reason: ${kickReason}`)
+    bot = null
+
+    expect(kickReason).not.toContain('[pin]')
+
+    const pinMatch = kickReason.match(/pin is (\d{6})/)
+    expect(pinMatch).not.toBeNull()
+
+    if (pinMatch != null) {
+      const pin = pinMatch[1]
+      console.log(`Extracted pin from online kick message: ${pin}`)
+      expect(pin).toMatch(/^\d{6}$/)
+    }
+  }, TEST_TIMEOUT_MS)
+
+  test('[pin] placeholder in kick message is replaced when tempbanning an online player', async () => {
+    bot = await createBot(KICK_USERNAME)
+    const kickPromise = bot.waitForKick()
+
+    await sleep(1000)
+    const tempbanResponse = await sendCommand(`bmtempban ${KICK_USERNAME} 1h Testing online tempban kick pin`)
+    console.log(`Tempban response: ${tempbanResponse}`)
+
+    const kickReason = await kickPromise
+    console.log(`Online player kicked (tempban) with reason: ${kickReason}`)
+    bot = null
+
+    expect(kickReason).not.toContain('[pin]')
+
+    const pinMatch = kickReason.match(/pin is (\d{6})/)
+    expect(pinMatch).not.toBeNull()
+
+    if (pinMatch != null) {
+      const pin = pinMatch[1]
+      console.log(`Extracted pin from online tempban kick message: ${pin}`)
       expect(pin).toMatch(/^\d{6}$/)
     }
   }, TEST_TIMEOUT_MS)

--- a/e2e/tests/src/helpers/bot.ts
+++ b/e2e/tests/src/helpers/bot.ts
@@ -6,7 +6,40 @@ const SERVER_PORT = parseInt(process.env.SERVER_PORT ?? '25565', 10)
 const MC_VERSION = process.env.MC_VERSION ?? undefined
 
 /**
- * Extract text from a kick reason (string on Bukkit, ChatMessage object on Fabric)
+ * Extract text from an NBT compound chat component (Paper 1.20.5+ sends kick
+ * reasons as PrismarineNBT compounds instead of JSON chat components).
+ */
+function extractNbtText (nbt: Record<string, unknown>): string {
+  const value = nbt.value as Record<string, unknown>
+  let result = ''
+
+  const textField = value.text as Record<string, unknown> | undefined
+  if (textField?.type === 'string' && typeof textField.value === 'string') {
+    result += textField.value
+  }
+
+  const extra = value.extra as Record<string, unknown> | undefined
+  if (extra?.type === 'list') {
+    const listVal = extra.value as Record<string, unknown>
+    const items = listVal?.value
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        if (typeof item === 'object' && item != null) {
+          const t = (item as Record<string, unknown>).text as Record<string, unknown> | undefined
+          if (t?.type === 'string' && typeof t.value === 'string') {
+            result += t.value
+          }
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Extract text from a kick reason (string on Bukkit, ChatMessage object on
+ * Fabric, or NBT compound on newer Paper).
  */
 function extractKickReason (reason: unknown): string {
   if (typeof reason === 'string') {
@@ -14,6 +47,11 @@ function extractKickReason (reason: unknown): string {
   }
   if (reason != null && typeof reason === 'object') {
     const reasonObj = reason as Record<string, unknown>
+
+    if (reasonObj.type === 'compound' && reasonObj.value != null) {
+      return extractNbtText(reasonObj)
+    }
+
     if (typeof reasonObj.toString === 'function') {
       const result = reasonObj.toString()
       if (result !== '[object Object]') {
@@ -315,12 +353,17 @@ export class TestBot {
       })
 
       bot.once('end', (reason) => {
-        if (settled) return
-        settled = true
-        clearTimeout(timeout)
-        bot.removeAllListeners('kicked')
-        this.bot = null
-        reject(new Error(`Bot disconnected before kick: ${reason}`))
+        // Delay before rejecting — mineflayer can fire 'end' (socketClosed) before
+        // 'kicked' when the server closes the TCP connection immediately after
+        // sending the disconnect packet. Give 'kicked' a chance to arrive first.
+        setTimeout(() => {
+          if (settled) return
+          settled = true
+          clearTimeout(timeout)
+          bot.removeAllListeners('kicked')
+          this.bot = null
+          reject(new Error(`Bot disconnected before kick: ${reason}`))
+        }, 500)
       })
     })
   }

--- a/e2e/tests/src/helpers/bot.ts
+++ b/e2e/tests/src/helpers/bot.ts
@@ -102,7 +102,7 @@ export class TestBot {
     return this._username
   }
 
-  async connect (): Promise<void> {
+  async connect (connectTimeoutMs: number = 30000): Promise<void> {
     return await new Promise((resolve, reject) => {
       console.log(`Connecting bot ${this._username} to ${SERVER_HOST}:${SERVER_PORT}`)
 
@@ -134,7 +134,7 @@ export class TestBot {
 
       const timeout = setTimeout(() => {
         cleanup(() => reject(new Error('Bot connection timeout')))
-      }, 30000)
+      }, connectTimeoutMs)
 
       this.bot.once('spawn', () => {
         clearTimeout(timeout)

--- a/e2e/tests/src/helpers/bot.ts
+++ b/e2e/tests/src/helpers/bot.ts
@@ -288,6 +288,43 @@ export class TestBot {
     }
   }
 
+  async waitForKick (timeoutMs: number = 30000): Promise<string> {
+    if (this.bot == null) {
+      throw new Error('Bot not connected')
+    }
+
+    const bot = this.bot
+    bot.removeAllListeners('kicked')
+
+    return await new Promise((resolve, reject) => {
+      let settled = false
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true
+          reject(new Error('Timeout waiting for kick'))
+        }
+      }, timeoutMs)
+
+      bot.once('kicked', (reason) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        bot.removeAllListeners('end')
+        this.bot = null
+        resolve(extractKickReason(reason))
+      })
+
+      bot.once('end', (reason) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        bot.removeAllListeners('kicked')
+        this.bot = null
+        reject(new Error(`Bot disconnected before kick: ${reason}`))
+      })
+    })
+  }
+
   private async sleep (ms: number): Promise<void> {
     return await new Promise((resolve) => setTimeout(resolve, ms))
   }

--- a/e2e/tests/src/helpers/bot.ts
+++ b/e2e/tests/src/helpers/bot.ts
@@ -115,7 +115,16 @@ export class TestBot {
         version: MC_VERSION
       })
 
+      const cleanup = (): void => {
+        if (this.bot != null) {
+          this.bot.removeAllListeners()
+          this.bot.end()
+          this.bot = null
+        }
+      }
+
       const timeout = setTimeout(() => {
+        cleanup()
         reject(new Error('Bot connection timeout'))
       }, 30000)
 
@@ -127,6 +136,7 @@ export class TestBot {
 
       this.bot.once('error', (err) => {
         clearTimeout(timeout)
+        cleanup()
         reject(err)
       })
 
@@ -134,6 +144,7 @@ export class TestBot {
         clearTimeout(timeout)
         const reasonText = extractKickReason(reason)
         console.log(`Bot ${this._username} was kicked: ${reasonText}`)
+        cleanup()
         reject(new Error(`Bot ${this._username} was kicked: ${reasonText}`))
       })
 
@@ -347,7 +358,8 @@ export class TestBot {
         if (settled) return
         settled = true
         clearTimeout(timeout)
-        bot.removeAllListeners('end')
+        bot.removeAllListeners()
+        bot.end()
         this.bot = null
         resolve(extractKickReason(reason))
       })
@@ -360,7 +372,7 @@ export class TestBot {
           if (settled) return
           settled = true
           clearTimeout(timeout)
-          bot.removeAllListeners('kicked')
+          bot.removeAllListeners()
           this.bot = null
           reject(new Error(`Bot disconnected before kick: ${reason}`))
         }, 500)

--- a/e2e/tests/src/helpers/bot.ts
+++ b/e2e/tests/src/helpers/bot.ts
@@ -115,17 +115,25 @@ export class TestBot {
         version: MC_VERSION
       })
 
-      const cleanup = (): void => {
+      const cleanup = (callback: () => void): void => {
         if (this.bot != null) {
-          this.bot.removeAllListeners()
-          this.bot.end()
+          const b = this.bot
           this.bot = null
+
+          const fallback = setTimeout(() => callback(), 1500)
+
+          b.once('end', () => {
+            clearTimeout(fallback)
+            callback()
+          })
+          b.end()
+        } else {
+          callback()
         }
       }
 
       const timeout = setTimeout(() => {
-        cleanup()
-        reject(new Error('Bot connection timeout'))
+        cleanup(() => reject(new Error('Bot connection timeout')))
       }, 30000)
 
       this.bot.once('spawn', () => {
@@ -136,16 +144,14 @@ export class TestBot {
 
       this.bot.once('error', (err) => {
         clearTimeout(timeout)
-        cleanup()
-        reject(err)
+        cleanup(() => reject(err))
       })
 
       this.bot.once('kicked', (reason) => {
         clearTimeout(timeout)
         const reasonText = extractKickReason(reason)
         console.log(`Bot ${this._username} was kicked: ${reasonText}`)
-        cleanup()
-        reject(new Error(`Bot ${this._username} was kicked: ${reasonText}`))
+        cleanup(() => reject(new Error(`Bot ${this._username} was kicked: ${reasonText}`)))
       })
 
       this.bot.on('chat', (username, message) => {
@@ -358,10 +364,24 @@ export class TestBot {
         if (settled) return
         settled = true
         clearTimeout(timeout)
-        bot.removeAllListeners()
+        const kickReason = extractKickReason(reason)
+
+        // Wait for the 'end' event so mineflayer's internal cleanup (physics
+        // timer clearInterval) runs before we resolve. Resolving immediately
+        // lets the test finish and Jest tear down while the physics tick is
+        // still running, causing a ReferenceError.
+        const endTimeout = setTimeout(() => {
+          this.bot = null
+          resolve(kickReason)
+        }, 1500)
+
+        bot.once('end', () => {
+          clearTimeout(endTimeout)
+          this.bot = null
+          resolve(kickReason)
+        })
+
         bot.end()
-        this.bot = null
-        resolve(extractKickReason(reason))
       })
 
       bot.once('end', (reason) => {
@@ -372,7 +392,6 @@ export class TestBot {
           if (settled) return
           settled = true
           clearTimeout(timeout)
-          bot.removeAllListeners()
           this.bot = null
           reject(new Error(`Bot disconnected before kick: ${reason}`))
         }, 500)

--- a/fabric/src/main/java/me/confuser/banmanager/webenhancer/fabric/listeners/EventListener.java
+++ b/fabric/src/main/java/me/confuser/banmanager/webenhancer/fabric/listeners/EventListener.java
@@ -1,5 +1,6 @@
 package me.confuser.banmanager.webenhancer.fabric.listeners;
 
+import me.confuser.banmanager.common.data.PlayerBanData;
 import me.confuser.banmanager.common.data.PlayerData;
 import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.fabric.BanManagerEvents;
@@ -15,13 +16,19 @@ public class EventListener {
         this.plugin = plugin;
         this.deniedListener = new CommonPlayerDeniedListener(plugin);
 
-        // Wire BanManager Fabric events
         BanManagerEvents.PLAYER_DENIED_EVENT.register(this::onPlayerDenied);
+        BanManagerEvents.PLAYER_BANNED_EVENT.register(this::onPlayerBanned);
         BanManagerEvents.PLUGIN_RELOADED_EVENT.register(this::onReload);
     }
 
     private void onPlayerDenied(PlayerData player, Message message) {
         deniedListener.handlePin(player, message);
+    }
+
+    private void onPlayerBanned(PlayerBanData banData, boolean silent, Message kickMessage) {
+        if (kickMessage != null) {
+            deniedListener.handlePin(banData.getPlayer(), kickMessage);
+        }
     }
 
     private void onReload(PlayerData actor) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=me.confuser.banmanager.webenhancer
-version=7.7.0-SNAPSHOT
+version=7.11.0-SNAPSHOT
 org.gradle.parallel=true
 
 org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -XX:MaxGCPauseMillis=200

--- a/sponge-api7/src/main/java/me/confuser/banmanager/webenhancer/sponge/listeners/ReportListener.java
+++ b/sponge-api7/src/main/java/me/confuser/banmanager/webenhancer/sponge/listeners/ReportListener.java
@@ -1,10 +1,12 @@
 package me.confuser.banmanager.webenhancer.sponge.listeners;
 
 import me.confuser.banmanager.common.ormlite.stmt.DeleteBuilder;
+import me.confuser.banmanager.sponge.api.events.PlayerBannedEvent;
 import me.confuser.banmanager.sponge.api.events.PlayerReportDeletedEvent;
 import me.confuser.banmanager.sponge.api.events.PlayerReportedEvent;
 import me.confuser.banmanager.sponge.api.events.PlayerDeniedEvent;
 import me.confuser.banmanager.sponge.api.events.PluginReloadedEvent;
+import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.common.data.PlayerReportData;
 import me.confuser.banmanager.webenhancer.sponge.SpongePlugin;
 import me.confuser.banmanager.webenhancer.common.data.LogData;
@@ -77,6 +79,17 @@ public class ReportListener {
   @Listener(order = Order.BEFORE_POST)
   public void onDeny(final PlayerDeniedEvent event) {
     listener.handlePin(event.getPlayer(), event.getMessage());
+  }
+
+  @Listener(order = Order.POST)
+  public void onBanned(PlayerBannedEvent event) {
+    try {
+      Message kickMessage = event.getKickMessage();
+      if (kickMessage != null) {
+        listener.handlePin(event.getBan().getPlayer(), kickMessage);
+      }
+    } catch (NoSuchMethodError ignored) {
+    }
   }
 
   @Listener

--- a/sponge/src/main/java/me/confuser/banmanager/webenhancer/sponge/listeners/ReportListener.java
+++ b/sponge/src/main/java/me/confuser/banmanager/webenhancer/sponge/listeners/ReportListener.java
@@ -1,10 +1,12 @@
 package me.confuser.banmanager.webenhancer.sponge.listeners;
 
 import me.confuser.banmanager.common.ormlite.stmt.DeleteBuilder;
+import me.confuser.banmanager.sponge.api.events.PlayerBannedEvent;
 import me.confuser.banmanager.sponge.api.events.PlayerReportDeletedEvent;
 import me.confuser.banmanager.sponge.api.events.PlayerReportedEvent;
 import me.confuser.banmanager.sponge.api.events.PlayerDeniedEvent;
 import me.confuser.banmanager.sponge.api.events.PluginReloadedEvent;
+import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.common.data.PlayerReportData;
 import me.confuser.banmanager.webenhancer.sponge.SpongePlugin;
 import me.confuser.banmanager.webenhancer.common.data.LogData;
@@ -75,6 +77,17 @@ public class ReportListener {
     @Listener(order = Order.BEFORE_POST)
     public void onDeny(final PlayerDeniedEvent event) {
         listener.handlePin(event.getPlayer(), event.getMessage());
+    }
+
+    @Listener(order = Order.POST)
+    public void onBanned(PlayerBannedEvent event) {
+        try {
+            Message kickMessage = event.getKickMessage();
+            if (kickMessage != null) {
+                listener.handlePin(event.getBan().getPlayer(), kickMessage);
+            }
+        } catch (NoSuchMethodError ignored) {
+        }
     }
 
     @Listener

--- a/velocity/src/main/java/me/confuser/banmanager/webenhancer/velocity/listener/BanListener.java
+++ b/velocity/src/main/java/me/confuser/banmanager/webenhancer/velocity/listener/BanListener.java
@@ -2,7 +2,9 @@ package me.confuser.banmanager.webenhancer.velocity.listener;
 
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
+import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.velocity.Listener;
+import me.confuser.banmanager.velocity.api.events.PlayerBannedEvent;
 import me.confuser.banmanager.velocity.api.events.PlayerDeniedEvent;
 import me.confuser.banmanager.webenhancer.common.listeners.CommonPlayerDeniedListener;
 import me.confuser.banmanager.webenhancer.velocity.VelocityPlugin;
@@ -19,6 +21,17 @@ public class BanListener extends Listener {
     @Subscribe
     public void onDeny(PlayerDeniedEvent event) {
         listener.handlePin(event.getPlayer(), event.getMessage());
+    }
+
+    @Subscribe
+    public void onBanned(PlayerBannedEvent event) {
+        try {
+            Message kickMessage = event.getKickMessage();
+            if (kickMessage != null) {
+                listener.handlePin(event.getBan().getPlayer(), kickMessage);
+            }
+        } catch (NoSuchMethodError ignored) {
+        }
     }
 
     @Subscribe


### PR DESCRIPTION
Listen to PlayerBannedEvent on all 6 platforms to call handlePin when a kickMessage is present, enabling [pin] replacement on the first kick of an online player (not just reconnect denial).

Change ExpiresSync from extends BmRunnable to implements Runnable to eliminate the spurious "unknown last checked pinCheck" log on every boot.

Add e2e tests verifying the kick message contains a 6-digit pin when banning/tempbanning an online player. Add waitForKick() helper to TestBot with proper listener cleanup and race-safe settlement.