### PR TITLE
fix: add default log filters for HikariDataSource and TableUtils

### DIFF
--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -14,3 +14,5 @@ ignoreContains:
 - '[PlugMan]'
 - 'Metrics'
 - 'For help, type "help"'
+- 'HikariDataSource'
+- 'TableUtils'

--- a/e2e/platforms/bukkit/configs/banmanager-webenhancer/config.yml
+++ b/e2e/platforms/bukkit/configs/banmanager-webenhancer/config.yml
@@ -14,4 +14,6 @@ ignoreContains:
 - '[PlugMan]'
 - 'Metrics'
 - 'For help, type "help"'
+- 'HikariDataSource'
+- 'TableUtils'
 

--- a/e2e/platforms/bungee/configs/banmanager-webenhancer/config.yml
+++ b/e2e/platforms/bungee/configs/banmanager-webenhancer/config.yml
@@ -12,3 +12,5 @@ ignoreContains:
 - '[PlugMan]'
 - Metrics
 - For help, type "help"
+- 'HikariDataSource'
+- 'TableUtils'

--- a/e2e/platforms/fabric/configs/banmanager-webenhancer/config.yml
+++ b/e2e/platforms/fabric/configs/banmanager-webenhancer/config.yml
@@ -14,4 +14,6 @@ ignoreContains:
 - '[PlugMan]'
 - 'Metrics'
 - 'For help, type "help"'
+- 'HikariDataSource'
+- 'TableUtils'
 

--- a/e2e/platforms/sponge/configs/banmanager-webenhancer/config.yml
+++ b/e2e/platforms/sponge/configs/banmanager-webenhancer/config.yml
@@ -14,4 +14,6 @@ ignoreContains:
 - '[PlugMan]'
 - 'Metrics'
 - 'For help, type "help"'
+- 'HikariDataSource'
+- 'TableUtils'
 

--- a/e2e/platforms/sponge7/configs/banmanager-webenhancer/config.yml
+++ b/e2e/platforms/sponge7/configs/banmanager-webenhancer/config.yml
@@ -14,4 +14,6 @@ ignoreContains:
 - '[PlugMan]'
 - 'Metrics'
 - 'For help, type "help"'
+- 'HikariDataSource'
+- 'TableUtils'
 

--- a/e2e/platforms/velocity/configs/banmanager-webenhancer/config.yml
+++ b/e2e/platforms/velocity/configs/banmanager-webenhancer/config.yml
@@ -14,3 +14,5 @@ ignoreContains:
 - '[PlugMan]'
 - 'Metrics'
 - 'For help, type "help"'
+- 'HikariDataSource'
+- 'TableUtils'

--- a/e2e/tests/src/log-filtering.test.ts
+++ b/e2e/tests/src/log-filtering.test.ts
@@ -231,4 +231,54 @@ describeOrSkip('Log Filtering (ignoreContains)', () => {
       console.log('Report command output correctly filtered')
     }
   }, 60000)
+
+  test('HikariDataSource messages are filtered from report logs', async () => {
+    const uniqueId = Date.now()
+    const hikariMessage = `HikariDataSource pool starting_${uniqueId}`
+    const normalMessage = `NormalMarkerHikari_${uniqueId}`
+    const logs = await captureLogsForReason(
+      'Testing HikariDataSource filter',
+      normalMessage,
+      async () => {
+        await sendCommand(`say ${hikariMessage}`)
+        await sendCommand(`say ${normalMessage}`)
+      }
+    )
+
+    expect(logs).not.toBeNull()
+    if (logs != null) {
+      const hikariFound = logs.some(log => log.message.includes(hikariMessage))
+      expect(hikariFound).toBe(false)
+
+      const normalFound = logs.some(log => log.message.includes(normalMessage))
+      expect(normalFound).toBe(true)
+
+      console.log('HikariDataSource messages correctly filtered')
+    }
+  }, 60000)
+
+  test('TableUtils messages are filtered from report logs', async () => {
+    const uniqueId = Date.now()
+    const tableUtilsMessage = `TableUtils creating table_${uniqueId}`
+    const normalMessage = `NormalMarkerTableUtils_${uniqueId}`
+    const logs = await captureLogsForReason(
+      'Testing TableUtils filter',
+      normalMessage,
+      async () => {
+        await sendCommand(`say ${tableUtilsMessage}`)
+        await sendCommand(`say ${normalMessage}`)
+      }
+    )
+
+    expect(logs).not.toBeNull()
+    if (logs != null) {
+      const tableUtilsFound = logs.some(log => log.message.includes(tableUtilsMessage))
+      expect(tableUtilsFound).toBe(false)
+
+      const normalFound = logs.some(log => log.message.includes(normalMessage))
+      expect(normalFound).toBe(true)
+
+      console.log('TableUtils messages correctly filtered')
+    }
+  }, 60000)
 })

--- a/e2e/tests/src/log-filtering.test.ts
+++ b/e2e/tests/src/log-filtering.test.ts
@@ -260,7 +260,7 @@ describeOrSkip('Log Filtering (ignoreContains)', () => {
   test('TableUtils messages are filtered from report logs', async () => {
     const uniqueId = Date.now()
     const tableUtilsMessage = `TableUtils creating table_${uniqueId}`
-    const normalMessage = `NormalMarkerTableUtils_${uniqueId}`
+    const normalMessage = `NormalMarkerTblUtils_${uniqueId}`
     const logs = await captureLogsForReason(
       'Testing TableUtils filter',
       normalMessage,


### PR DESCRIPTION
After BanManager routes HikariCP/ORMLite output through the plugin logger instead of System.err, these messages become visible to WebEnhancer's log appender. Add default ignoreContains entries to filter out DB startup noise from report logs, and add E2E tests for the new filters.

Related: BanManagement/BanManager#1050