### PR TITLE
chore: prepare for next release

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     api(project(":BanManagerWebEnhancerCommon")) {
         isTransitive = true
     }
-    compileOnly("me.confuser.banmanager:BanManagerBukkit:7.11.0-SNAPSHOT")
+    compileOnly("me.confuser.banmanager:BanManagerBukkit:8.0.0-SNAPSHOT")
 
     compileOnly("org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT") {
         exclude("junit", "junit")

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     api(project(":BanManagerWebEnhancerCommon")) {
         isTransitive = true
     }
-    compileOnly("me.confuser.banmanager:BanManagerBungee:7.11.0-SNAPSHOT")
+    compileOnly("me.confuser.banmanager:BanManagerBungee:8.0.0-SNAPSHOT")
 
     compileOnly("net.md-5:bungeecord-api:1.21-R0.4")
     "shadeOnly"("org.bstats:bstats-bungeecord:2.2.1")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,8 +8,8 @@ applyPlatformAndCoreConfiguration()
 dependencies {
     api(project(":BanManagerWebEnhancerLibs"))
 
-    api("me.confuser.banmanager:BanManagerCommon:7.11.0-SNAPSHOT")
-    api("me.confuser.banmanager.BanManagerLibs:BanManagerLibs:7.11.0-SNAPSHOT")
+    api("me.confuser.banmanager:BanManagerCommon:8.0.0-SNAPSHOT")
+    api("me.confuser.banmanager.BanManagerLibs:BanManagerLibs:8.0.0-SNAPSHOT")
 
     // Test dependencies
     testImplementation("junit:junit:4.13")

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
     // 1.21.11 runtime support exists in BanManager, but public artifacts may lag behind;
     // compile against 1.21.4 API-compatible classes until 1.21.11 artifacts are published.
     val banManagerCompileMcVersion = if (minecraftVersion == "1.21.11") "1.21.4" else minecraftVersion
-    modCompileOnly("me.confuser.banmanager:BanManagerFabric-mc$banManagerCompileMcVersion:7.11.0-SNAPSHOT")
+    modCompileOnly("me.confuser.banmanager:BanManagerFabric-mc$banManagerCompileMcVersion:8.0.0-SNAPSHOT")
 }
 
 tasks.named<Copy>("processResources") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=me.confuser.banmanager.webenhancer
-version=7.11.0-SNAPSHOT
+version=8.0.0-SNAPSHOT
 org.gradle.parallel=true
 
 org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -XX:MaxGCPauseMillis=200

--- a/sponge-api7/build.gradle.kts
+++ b/sponge-api7/build.gradle.kts
@@ -69,7 +69,7 @@ configurations {
 
 dependencies {
     compileOnly("org.spongepowered:spongeapi:7.2.0")
-    compileOnly("me.confuser.banmanager:BanManagerSponge7:7.11.0-SNAPSHOT")
+    compileOnly("me.confuser.banmanager:BanManagerSponge7:8.0.0-SNAPSHOT")
     compileOnly("org.apache.logging.log4j:log4j-core:2.17.0")
 
     api(project(":BanManagerWebEnhancerCommon")) {

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -36,7 +36,7 @@ sponge {
         dependency("banmanager") {
             loadOrder(org.spongepowered.plugin.metadata.model.PluginDependency.LoadOrder.AFTER)
             optional(false)
-            version("7.11.0-SNAPSHOT")
+            version("8.0.0-SNAPSHOT")
         }
     }
 }
@@ -54,7 +54,7 @@ configurations {
 
 dependencies {
     compileOnly("org.spongepowered:spongeapi:11.0.0")
-    compileOnly("me.confuser.banmanager:BanManagerSponge:7.11.0-SNAPSHOT")
+    compileOnly("me.confuser.banmanager:BanManagerSponge:8.0.0-SNAPSHOT")
 
     api(project(":BanManagerWebEnhancerCommon")) {
         isTransitive = true

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     api(project(":BanManagerWebEnhancerCommon")) {
         isTransitive = true
     }
-    compileOnly("me.confuser.banmanager:BanManagerVelocity:7.11.0-SNAPSHOT")
+    compileOnly("me.confuser.banmanager:BanManagerVelocity:8.0.0-SNAPSHOT")
 
     compileOnly("com.velocitypowered:velocity-api:3.1.0")
     annotationProcessor("com.velocitypowered:velocity-api:3.1.0")


### PR DESCRIPTION
## Summary

Bumps WebEnhancer master from `7.11.0-SNAPSHOT` directly to `8.0.0-SNAPSHOT`, and re-pins all `me.confuser.banmanager:*` `compileOnly` + `api` dependencies and the Sponge plugin metadata version constraint to BanManager `8.0.0-SNAPSHOT`.

This follows BanManager master being bumped to `8.0.0-SNAPSHOT` in BanManager#1068.

## Branch model after this lands

- `master` → `8.0.0-SNAPSHOT` (active development, builds against BanManager `8.0.0-SNAPSHOT`)
- `release/v7` → `7.11.1-SNAPSHOT` (maintenance, builds against BanManager `7.11.0`)

## Note on v8 compat work

The actual v8 compat code is currently parked on `feat/v8-compat` (commit `1ed4c6f`). That branch will need to be rebased / re-targeted at the new `8.0.0-SNAPSHOT` master and merged in once BanManager v8 ships and the WebEnhancer integration surface is finalised.

## Test plan

- [x] `gradle.properties` updated
- [x] All seven build modules' BanManager deps re-pinned to `8.0.0-SNAPSHOT`
- [x] Sponge plugin metadata version constraint updated to `8.0.0-SNAPSHOT`
- [ ] CI green (note: WebEnhancer CI checks out BanManager master, which is now `8.0.0-SNAPSHOT` — should resolve)