### PR TITLE
ci: extend Java CI / E2E triggers to release/v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release/v7
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - release/v7
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Mirrors the matching change already on release/v7 (commit 612ebc7).

- build.yml + e2e.yml: add release/v7 to push branches

PR triggers were already unconditional, so this only affects pushes (i.e. merged PRs and release commits) on release/v7.

## Test plan
- [x] release/v7 already carries the matching change
- [ ] Once merged, master + release/v7 will share identical workflow triggers