### PR TITLE
chore: finish Java 17 bump in libs and use Message.sendTo in PinCommand

### DIFF
--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -35,8 +35,8 @@ fun Project.applyLibrariesConfiguration() {
     }
 
     plugins.withId("java") {
-        the<JavaPluginExtension>().setSourceCompatibility("1.8")
-        the<JavaPluginExtension>().setTargetCompatibility("1.8")
+        the<JavaPluginExtension>().setSourceCompatibility("17")
+        the<JavaPluginExtension>().setTargetCompatibility("17")
     }
 
     group = "${rootProject.group}.BanManagerWebEnhancerLibs"
@@ -89,7 +89,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
         }
         outgoing.artifact(tasks.named("jar"))
     }
@@ -104,7 +104,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
         }
         outgoing.artifact(tasks.named("jar"))
     }

--- a/common/src/main/java/me/confuser/banmanager/webenhancer/common/commands/PinCommand.java
+++ b/common/src/main/java/me/confuser/banmanager/webenhancer/common/commands/PinCommand.java
@@ -42,7 +42,7 @@ public class PinCommand extends CommonCommand {
       try {
         player = getPlugin().getPlayerStorage().queryForId(sender.getData().getId());
       } catch (SQLException e) {
-        sender.sendMessage(Message.get("sender.error.exception").toString());
+        Message.get("sender.error.exception").sendTo(sender);
         e.printStackTrace();
         return;
       }
@@ -50,7 +50,7 @@ public class PinCommand extends CommonCommand {
       PlayerPinData pin = plugin.getPlayerPinStorage().getValidPin(player);
 
       if (pin == null) {
-        sender.sendMessage(Message.get("sender.error.exception").toString());
+        Message.get("sender.error.exception").sendTo(sender);
         return;
       }
 


### PR DESCRIPTION
## Summary

Two small cleanups salvaged from the now-closed #36 that #40 didn't pick up.

- **`buildSrc/src/main/kotlin/LibsConfig.kt`** — bump the `libs` module's `sourceCompatibility` / `targetCompatibility` and the published `TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE` from `1.8` → `17`. #40 raised the rest of the project's Java baseline to 17 (in `CommonConfig.kt`) but left the `libs` module pinned at 1.8, so its published artifact metadata still advertised JVM 8 even though the contents were now compiled by a Java 17 toolchain. This brings them into agreement.
- **`common/.../commands/PinCommand.java`** — replace the two remaining `sender.sendMessage(Message.get("sender.error.exception").toString())` calls with `Message.get("sender.error.exception").sendTo(sender)`, matching the style used everywhere else in the file (and the rest of the v8 codebase) so the error is rendered through the MiniMessage pipeline rather than as the raw `Component.toString()` output.

No behaviour changes beyond those two lines of error rendering and the `libs` JAR's published metadata.

## Test plan

- [x] `./gradlew :BanManagerWebEnhancerCommon:compileJava` — green locally.
- [x] `./gradlew :BanManagerWebEnhancerLibs:jar` runs as part of the above and produces a Java 17 jar without warnings.
- [ ] CI: `Java CI` build + the 10 E2E suites (no behaviour change expected).

## Context

- Closes the leftover scope from #36 (closed as superseded).
- Builds on #40 (Java 17 baseline + MiniMessage migration).