### PR TITLE
chore: modernise build and tests for Java 17 baseline

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
     implementation("org.jfrog.buildinfo:build-info-extractor-gradle:5.2.5")
     implementation("org.spongepowered:spongegradle-plugin-development:2.3.0")
     implementation("fabric-loom:fabric-loom.gradle.plugin:1.15.3")
+    implementation("com.vanniktech:gradle-maven-publish-plugin:0.35.0")
 }

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -17,11 +17,11 @@ fun Project.applyCommonConfiguration() {
     }
 
     dependencies {
-        "compileOnly"("org.projectlombok:lombok:1.18.36")
-        "annotationProcessor"("org.projectlombok:lombok:1.18.36")
+        "compileOnly"("org.projectlombok:lombok:1.18.38")
+        "annotationProcessor"("org.projectlombok:lombok:1.18.38")
 
-        "testCompileOnly"("org.projectlombok:lombok:1.18.36")
-        "testAnnotationProcessor"("org.projectlombok:lombok:1.18.36")
+        "testCompileOnly"("org.projectlombok:lombok:1.18.38")
+        "testAnnotationProcessor"("org.projectlombok:lombok:1.18.38")
     }
 
     configurations.all {

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -35,8 +35,8 @@ fun Project.applyLibrariesConfiguration() {
     }
 
     plugins.withId("java") {
-        the<JavaPluginExtension>().setSourceCompatibility("1.8")
-        the<JavaPluginExtension>().setTargetCompatibility("1.8")
+        the<JavaPluginExtension>().setSourceCompatibility("17")
+        the<JavaPluginExtension>().setTargetCompatibility("17")
     }
 
     group = "${rootProject.group}.BanManagerWebEnhancerLibs"
@@ -89,7 +89,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
         }
         outgoing.artifact(tasks.named("jar"))
     }
@@ -104,7 +104,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
         }
         outgoing.artifact(tasks.named("jar"))
     }

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -25,7 +25,7 @@ fun Project.applyPlatformAndCoreConfiguration() {
 
     ext["internalVersion"] = "$version"
 
-    // Java 8 turns on doclint which we fail
+    // Suppress doclint to keep javadoc builds green; tags below document supported custom tags.
     tasks.withType<Javadoc>().configureEach {
         (options as StandardJavadocDocletOptions).apply {
             addStringOption("Xdoclint:none", "-quiet")

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
         exclude("junit", "junit")
     }
     compileOnly("org.apache.logging.log4j:log4j-core:2.17.0")
-    "shadeOnly"("org.bstats:bstats-bukkit:2.2.1")
+    "shadeOnly"("org.bstats:bstats-bukkit:3.2.1")
 }
 
 tasks.named<Copy>("processResources") {

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     compileOnly("me.confuser.banmanager:BanManagerBungee:8.0.0-SNAPSHOT")
 
     compileOnly("net.md-5:bungeecord-api:1.21-R0.4")
-    "shadeOnly"("org.bstats:bstats-bungeecord:2.2.1")
+    "shadeOnly"("org.bstats:bstats-bungeecord:3.2.1")
 }
 
 tasks.named<Copy>("processResources") {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -11,24 +11,26 @@ dependencies {
     api("me.confuser.banmanager:BanManagerCommon:8.0.0-SNAPSHOT")
     api("me.confuser.banmanager.BanManagerLibs:BanManagerLibs:8.0.0-SNAPSHOT")
 
-    // Test dependencies
-    testImplementation("junit:junit:4.13")
-    testImplementation("org.mockito:mockito-core:4.0.0")
-    testImplementation("org.powermock:powermock-module-junit4:2.0.2")
-    testImplementation("org.powermock:powermock-api-mockito2:2.0.2")
-    testImplementation("ch.vorburger.mariaDB4j:mariaDB4j:2.6.0")
-    testImplementation("org.awaitility:awaitility:4.0.1")
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.mockito:mockito-core:5.14.2")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
+    testImplementation("ch.vorburger.mariaDB4j:mariaDB4j:3.3.1")
+    testImplementation("org.awaitility:awaitility:4.3.0")
 }
 
 tasks.withType<Test>().configureEach {
-    useJUnit()
+    useJUnitPlatform()
     maxHeapSize = "512m"
-    forkEvery = 1  // Fork a new JVM for each test class to prevent memory accumulation
+    // Fork a new JVM per test class - tests share JDBC/native fixtures that otherwise
+    // accumulate state across runs and hang the suite. See BanManager/common build.
+    forkEvery = 1
     finalizedBy(tasks.jacocoTestReport)
 }
 
 jacoco {
-    toolVersion = "0.8.11"
+    toolVersion = "0.8.12"
 }
 
 tasks.jacocoTestReport {

--- a/common/src/test/java/me/confuser/banmanager/webenhancer/common/data/PlayerPinDataTest.java
+++ b/common/src/test/java/me/confuser/banmanager/webenhancer/common/data/PlayerPinDataTest.java
@@ -1,12 +1,12 @@
 package me.confuser.banmanager.webenhancer.common.data;
 
 import me.confuser.banmanager.common.data.PlayerData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -23,8 +23,8 @@ public class PlayerPinDataTest {
         int pin = pinData.getGeneratedPin();
 
         // 6 digit pin: 100000-999999
-        assertTrue("Pin should be at least 100000", pin >= 100000);
-        assertTrue("Pin should be at most 999999", pin <= 999999);
+        assertTrue(pin >= 100000, "Pin should be at least 100000");
+        assertTrue(pin <= 999999, "Pin should be at most 999999");
     }
 
     @Test
@@ -35,8 +35,8 @@ public class PlayerPinDataTest {
         PlayerPinData pinData = new PlayerPinData(player);
         String hashedPin = pinData.getPin();
 
-        assertNotNull("Hashed pin should not be null", hashedPin);
-        assertTrue("Pin should be hashed with Argon2i", hashedPin.startsWith("$argon2i$"));
+        assertNotNull(hashedPin, "Hashed pin should not be null");
+        assertTrue(hashedPin.startsWith("$argon2i$"), "Pin should be hashed with Argon2i");
     }
 
     @Test
@@ -52,8 +52,7 @@ public class PlayerPinDataTest {
         long expires = pinData.getExpires();
 
         // Allow 1 second tolerance for test execution
-        assertTrue("Expiry should be ~300 seconds from creation",
-            expires >= beforeCreate + 299 && expires <= afterCreate + 301);
+        assertTrue(expires >= beforeCreate + 299 && expires <= afterCreate + 301, "Expiry should be ~300 seconds from creation");
     }
 
     @Test
@@ -66,9 +65,8 @@ public class PlayerPinDataTest {
         int generatedPin = pinData.getGeneratedPin();
         String hashedPin = pinData.getPin();
 
-        assertNotEquals("Generated pin should not be 0", 0, generatedPin);
-        assertFalse("Hashed pin should not equal plaintext",
-            hashedPin.equals(String.valueOf(generatedPin)));
+        assertNotEquals(0, generatedPin, "Generated pin should not be 0");
+        assertFalse(hashedPin.equals(String.valueOf(generatedPin)), "Hashed pin should not equal plaintext");
     }
 
     @Test
@@ -78,7 +76,7 @@ public class PlayerPinDataTest {
 
         PlayerPinData pinData = new PlayerPinData(player);
 
-        assertSame("Player reference should be stored", player, pinData.getPlayer());
+        assertSame(player, pinData.getPlayer(), "Player reference should be stored");
     }
 
     @Test
@@ -88,7 +86,7 @@ public class PlayerPinDataTest {
 
         PlayerPinData pinData = new PlayerPinData(player);
 
-        assertEquals("ID should be 0 before persistence", 0, pinData.getId());
+        assertEquals(0, pinData.getId(), "ID should be 0 before persistence");
     }
 
     @Test
@@ -105,7 +103,7 @@ public class PlayerPinDataTest {
             pin1.getGeneratedPin() != pin3.getGeneratedPin() ||
             pin2.getGeneratedPin() != pin3.getGeneratedPin();
 
-        assertTrue("At least two of three pins should differ", atLeastTwoDifferent);
+        assertTrue(atLeastTwoDifferent, "At least two of three pins should differ");
     }
 
     @Test
@@ -118,8 +116,7 @@ public class PlayerPinDataTest {
 
         // Even if by chance the generated pins are the same, the hashes should differ
         // due to unique random salts in Argon2
-        assertNotEquals("Hashes should differ due to random salts",
-            pin1.getPin(), pin2.getPin());
+        assertNotEquals(pin1.getPin(), pin2.getPin(), "Hashes should differ due to random salts");
     }
 
     @Test
@@ -130,6 +127,6 @@ public class PlayerPinDataTest {
         PlayerPinData pinData = new PlayerPinData(player);
         pinData.setGeneratedPin(999999);
 
-        assertEquals("Generated pin should be settable", 999999, pinData.getGeneratedPin());
+        assertEquals(999999, pinData.getGeneratedPin(), "Generated pin should be settable");
     }
 }

--- a/common/src/test/java/me/confuser/banmanager/webenhancer/common/listeners/CommonPlayerDeniedListenerTest.java
+++ b/common/src/test/java/me/confuser/banmanager/webenhancer/common/listeners/CommonPlayerDeniedListenerTest.java
@@ -5,16 +5,15 @@ import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.webenhancer.common.WebEnhancerPlugin;
 import me.confuser.banmanager.webenhancer.common.data.PlayerPinData;
 import me.confuser.banmanager.webenhancer.common.storage.PlayerPinStorage;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CommonPlayerDeniedListenerTest {
 
     @Mock
@@ -31,9 +30,9 @@ public class CommonPlayerDeniedListenerTest {
 
     private CommonPlayerDeniedListener listener;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        when(plugin.getPlayerPinStorage()).thenReturn(playerPinStorage);
+        lenient().when(plugin.getPlayerPinStorage()).thenReturn(playerPinStorage);
         listener = new CommonPlayerDeniedListener(plugin);
     }
 

--- a/common/src/test/java/me/confuser/banmanager/webenhancer/common/security/Argon2PasswordEncoderTest.java
+++ b/common/src/test/java/me/confuser/banmanager/webenhancer/common/security/Argon2PasswordEncoderTest.java
@@ -1,9 +1,9 @@
 package me.confuser.banmanager.webenhancer.common.security;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for Argon2PasswordEncoder.
@@ -12,7 +12,7 @@ public class Argon2PasswordEncoderTest {
 
     private Argon2PasswordEncoder encoder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         encoder = new Argon2PasswordEncoder();
     }
@@ -23,8 +23,8 @@ public class Argon2PasswordEncoderTest {
 
         String encoded = encoder.encode(password);
 
-        assertNotNull("Encoded password should not be null", encoded);
-        assertNotEquals("Encoded password should differ from original", password, encoded);
+        assertNotNull(encoded, "Encoded password should not be null");
+        assertNotEquals(password, encoded, "Encoded password should differ from original");
     }
 
     @Test
@@ -34,7 +34,7 @@ public class Argon2PasswordEncoderTest {
         String encoded = encoder.encode(password);
 
         // Argon2i format starts with $argon2i$
-        assertTrue("Hash should use Argon2i format", encoded.startsWith("$argon2i$"));
+        assertTrue(encoded.startsWith("$argon2i$"), "Hash should use Argon2i format");
     }
 
     @Test
@@ -44,7 +44,7 @@ public class Argon2PasswordEncoderTest {
         String encoded1 = encoder.encode(password);
         String encoded2 = encoder.encode(password);
 
-        assertNotEquals("Hashes should differ due to unique salts", encoded1, encoded2);
+        assertNotEquals(encoded1, encoded2, "Hashes should differ due to unique salts");
     }
 
     @Test
@@ -53,7 +53,7 @@ public class Argon2PasswordEncoderTest {
 
         String encoded = encoder.encode(password);
 
-        assertTrue("Hash string should be substantial", encoded.length() > 50);
+        assertTrue(encoded.length() > 50, "Hash string should be substantial");
     }
 
     @Test
@@ -62,8 +62,8 @@ public class Argon2PasswordEncoderTest {
 
         String encoded = encoder.encode(password);
 
-        assertNotNull("Should handle empty password", encoded);
-        assertTrue("Should still produce Argon2i format", encoded.startsWith("$argon2i$"));
+        assertNotNull(encoded, "Should handle empty password");
+        assertTrue(encoded.startsWith("$argon2i$"), "Should still produce Argon2i format");
     }
 
     @Test
@@ -75,8 +75,8 @@ public class Argon2PasswordEncoderTest {
 
         String encoded = encoder.encode(longPassword.toString());
 
-        assertNotNull("Should handle long password", encoded);
-        assertTrue("Should still produce Argon2i format", encoded.startsWith("$argon2i$"));
+        assertNotNull(encoded, "Should handle long password");
+        assertTrue(encoded.startsWith("$argon2i$"), "Should still produce Argon2i format");
     }
 
     @Test
@@ -85,8 +85,8 @@ public class Argon2PasswordEncoderTest {
 
         String encoded = encoder.encode(password);
 
-        assertNotNull("Should handle special characters", encoded);
-        assertTrue("Should still produce Argon2i format", encoded.startsWith("$argon2i$"));
+        assertNotNull(encoded, "Should handle special characters");
+        assertTrue(encoded.startsWith("$argon2i$"), "Should still produce Argon2i format");
     }
 
     @Test
@@ -96,14 +96,14 @@ public class Argon2PasswordEncoderTest {
 
         String encoded = encoder.encode(pin);
 
-        assertNotNull("Should handle numeric PIN", encoded);
-        assertTrue("Should produce Argon2i format", encoded.startsWith("$argon2i$"));
+        assertNotNull(encoded, "Should handle numeric PIN");
+        assertTrue(encoded.startsWith("$argon2i$"), "Should produce Argon2i format");
 
         // Verify format contains expected parameters
-        assertTrue("Should contain version", encoded.contains("v="));
-        assertTrue("Should contain memory parameter", encoded.contains("m="));
-        assertTrue("Should contain time parameter", encoded.contains("t="));
-        assertTrue("Should contain parallelism parameter", encoded.contains("p="));
+        assertTrue(encoded.contains("v="), "Should contain version");
+        assertTrue(encoded.contains("m="), "Should contain memory parameter");
+        assertTrue(encoded.contains("t="), "Should contain time parameter");
+        assertTrue(encoded.contains("p="), "Should contain parallelism parameter");
     }
 
     @Test
@@ -117,6 +117,6 @@ public class Argon2PasswordEncoderTest {
 
         String format2 = encoded2.substring(0, encoded2.indexOf("$", 9));
 
-        assertEquals("Both instances should produce same format", format1, format2);
+        assertEquals(format1, format2, "Both instances should produce same format");
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group=me.confuser.banmanager.webenhancer
 version=8.0.0-SNAPSHOT
 org.gradle.parallel=true
 
-org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -XX:MaxGCPauseMillis=200
+org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication

--- a/libs/build.gradle.kts
+++ b/libs/build.gradle.kts
@@ -4,8 +4,7 @@ applyLibrariesConfiguration()
 
 dependencies {
     "shade"("org.bouncycastle:bcprov-jdk15on:1.70")
-    "shade"("org.bouncycastle:bcpkix-jdk15on:1.70")
-    "shade"("com.google.guava:guava:17.0")
+    "shade"("com.google.guava:guava:33.4.8-jre")
 }
 
 tasks.withType<Jar>() {
@@ -17,15 +16,12 @@ tasks.named<ShadowJar>("jar") {
 
     dependencies {
         relocate("org.bouncycastle", "me.confuser.banmanager.webenhancer.common.bouncycastle") {
-            include(dependency("org.bouncycastle:bcpkix-jdk15on"))
             include(dependency("org.bouncycastle:bcprov-jdk15on"))
         }
 
         relocate("com.google.common", "me.confuser.banmanager.webenhancer.common.google.guava") {
             include(dependency("com.google.guava:guava"))
         }
-
-        include(dependency("org.bouncycastle:bcpkix-jdk15on"))
     }
 
     exclude("GradleStart**")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
 }
 
 plugins {
-    id("dev.kikugie.stonecutter") version "0.7.11"
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("dev.kikugie.stonecutter") version "0.8.3"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "BanManagerWebEnhancer"
@@ -37,10 +37,10 @@ stonecutter {
 
     shared {
         // Define version mappings for Fabric
-        vers("1.20.1", "1.20.1")
-        vers("1.21.1", "1.21.1")
-        vers("1.21.4", "1.21.4")
-        vers("1.21.11", "1.21.11")
+        version("1.20.1", "1.20.1")
+        version("1.21.1", "1.21.1")
+        version("1.21.4", "1.21.4")
+        version("1.21.11", "1.21.11")
     }
 
     create(":fabric")

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
         isTransitive = true
     }
 
-    "shadeOnly"("org.bstats:bstats-sponge:3.0.2")
+    "shadeOnly"("org.bstats:bstats-sponge:3.2.1")
 }
 
 // Sponge API 11+ requires Java 21

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
     compileOnly("com.velocitypowered:velocity-api:3.1.0")
     annotationProcessor("com.velocitypowered:velocity-api:3.1.0")
-    "shadeOnly"("org.bstats:bstats-velocity:3.0.0")
+    "shadeOnly"("org.bstats:bstats-velocity:3.2.1")
 }
 
 tasks.named<Copy>("processResources") {


### PR DESCRIPTION
## Summary

Companion to BanManager [PR #1070](https://github.com/BanManagement/BanManager/pull/1070).

Modernises the build and remaining tests for the Java 17 baseline that's already in use, refreshes a few outdated dependencies, and unifies the bStats versions across platforms.

## Changes

### Build

- Stonecutter `0.7.11` → `0.8.3` (`settings.gradle.kts` uses the renamed `shared.version()` API instead of `vers()`).
- Foojay toolchain resolver `0.9.0` → `1.0.0`.
- Added `com.vanniktech.maven.publish` to `buildSrc` so libs/sub-projects can publish consistently with BanManager.
- Set Libs `sourceCompatibility`/`targetCompatibility` and the `TargetJvmVersion` attribute to `17` (matches the Java 17 baseline already in use by other modules).
- Lombok `1.18.36` → `1.18.38`.
- bStats Bukkit/Bungee/Velocity/Sponge unified at `3.2.1` (was a mix of `2.2.1` / `3.0.0` / `3.0.2`).
- Guava `17.0` → `33.4.8-jre` and dropped the unused `bcpkix-jdk15on` shade (only `bcprov` is referenced by the Argon2 encoder).
- Append `-XX:+UseStringDeduplication` to the Gradle JVM args.

### Tests

- Migrated the three remaining tests (`PlayerPinDataTest`, `CommonPlayerDeniedListenerTest`, `Argon2PasswordEncoderTest`) from JUnit 4 + PowerMock + Mockito 4 to JUnit 5 + Mockito 5 (`mockito-junit-jupiter 5.14.2`). PowerMock dropped.
- `mariaDB4j 2.6.0` → `3.3.1`, `awaitility 4.0.1` → `4.3.0`, `jacoco 0.8.11` → `0.8.12`.
- Refreshed the `forkEvery=1` inline comment to point at the BanManager common build for full rationale (JDBC drivers and native fixtures leak across runs).

## Test plan

- [x] `./gradlew :BanManagerWebEnhancerCommon:test` - **22 tests, 0 skipped, 0 failures, 0 errors**.
- [x] Sequential `./gradlew build -x test` produces every artifact across Bukkit, Bungee, Velocity, Sponge, and all 4 Fabric variants (1.20.1, 1.21.1, 1.21.4, 1.21.11).
- [ ] CI (`build.yml` + `e2e.yml`) green.
- [ ] Smoke test on a real server alongside the BanManager modernisation PR (validates the SLF4J/HikariCP/MariaDB/MySQL upgrades over there don't regress WebEnhancer's pin/web flows).

## Notes

- The companion BanManager PR carries the bigger lift (HikariCP/ORMLite/JDBC driver upgrades, SLF4J 2.x, full JUnit 5 sweep across 67 test classes, DTOs to records). This PR is intentionally narrow.